### PR TITLE
Implement changes for dynamical offsets

### DIFF
--- a/hopper/hopper.py
+++ b/hopper/hopper.py
@@ -264,7 +264,7 @@ class CheckObsreqTargetFromPcad(CmdAction):
     """
     For science observations check that the expected target attitude
     (derived from the current TARG_Q_ATT and OR Y,Z offset) matches
-    the OR target attitude.
+    the OR target attitude to within 1 arcsec.
     """
     cmd_trigger = {'tlmsid': 'check_obsreq_target_from_pcad'}
 
@@ -323,12 +323,14 @@ class CheckObsreqTargetFromPcad(CmdAction):
             sep = targ.separation(cmd_targ)
             if sep < 1. * u.arcsec:
                 ok = True
-                message = 'science target attitude matches OR list for obsid {}'.format(obsid)
+                message = ('science target attitude matches OR list'
+                           ' (separation={:.1f})'
+                           .format(sep.to('arcsec')))
             else:
                 ok = False
                 message = ('science target attitude RA={:.5f} Dec={:.5f} different '
-                           'from OR list for obsid {} by {:.1f}'
-                           .format(q_targ.ra, q_targ.dec, obsid, sep.to('arcsec')))
+                           'from OR list (separation={:.1f})'
+                           .format(q_targ.ra, q_targ.dec, sep.to('arcsec')))
             check.update({'ok': ok, 'message': message})
 
         SC.checks[obsid].append(check)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(name='hopper',
       author='Tom Aldcroft',
       description='Load checking package',
       author_email='taldcroft@cfa.harvard.edu',
-      version='0.1',
+      version='0.2',
       zip_safe=False,
       packages=['hopper'],
       )


### PR DESCRIPTION
Implement changes to support checking PCAD attitudes for loads created with Matlab tools 2016_210 and later.  This implements the Cycle 18 aimpoint transition plan with ACA CCD-based dynamical aimpoint offsets.

This is being merged into a new long-running branch "starcheck" which corresponds to release 0.1.  Details to be discussed.

Goes along with https://github.com/sot/starcheck/issues/158.

Needs version update.  No unit testing, only functional test via starcheck.