### PR TITLE
Update to use parse_cm.read_or_list_full

### DIFF
--- a/hopper/pcad.py
+++ b/hopper/pcad.py
@@ -231,7 +231,7 @@ class AttitudeConsistentWithObsreqCheck(Check):
         elif obsid not in SC.obsreqs:
             self.add_message('error', 'obsid {} not in OR list'.format(obsid))
 
-        elif 'target_ra' not in SC.obsreqs[obsid]:
+        elif 'target' not in SC.obsreqs[obsid]:
             self.add_message('error', 'obsid {} does not have RA/Dec in OR'.format(obsid))
 
         else:
@@ -242,9 +242,9 @@ class AttitudeConsistentWithObsreqCheck(Check):
             # to science target attitude.  Add in the dynamical offset attributes
             # which are available for loads planned with Matlab tools 2016_210
             # and later.  These pseudo-attributes must be injected by calling code.
-            y_off = obsreq['target_offset_y'] + obsreq.get('aca_offset_y', 0)
-            z_off = obsreq['target_offset_z'] + obsreq.get('aca_offset_z', 0)
-            targ = SkyCoord(obsreq['target_ra'], obsreq['target_dec'], unit='deg')
+            y_off = obsreq['target_offset']['y_offset'] + obsreq.get('aca_offset_y', 0)
+            z_off = obsreq['target_offset']['z_offset'] + obsreq.get('aca_offset_z', 0)
+            targ = SkyCoord(obsreq['target']['ra'], obsreq['target']['dec'], unit='deg')
             pcad = Quat([SC.targ_q1, SC.targ_q2, SC.targ_q3, SC.targ_q4])
             detector = SC.detector
 

--- a/hopper/spacecraft.py
+++ b/hopper/spacecraft.py
@@ -314,7 +314,7 @@ def run_cmds(cmds, or_list=None, ofls_characteristics_file=None,
              initial_state=None, starcheck=False):
     if or_list is None:
         obsreqs = None
-    elif isinstance(or_list, list):
+    elif isinstance(or_list, dict):
         obsreqs = or_list
     else:
         obsreqs, comments = parse_cm.read_or_list_full(or_list)

--- a/hopper/spacecraft.py
+++ b/hopper/spacecraft.py
@@ -317,7 +317,7 @@ def run_cmds(cmds, or_list=None, ofls_characteristics_file=None,
     elif isinstance(or_list, dict):
         obsreqs = or_list
     else:
-        obsreqs, comments = parse_cm.read_or_list_full(or_list)
+        obsreqs, _ = parse_cm.read_or_list_full(or_list)
     if ofls_characteristics_file:
         odb_si_align = parse_cm.read_characteristics(ofls_characteristics_file,
                                                      item='ODB_SI_ALIGN')

--- a/hopper/spacecraft.py
+++ b/hopper/spacecraft.py
@@ -126,7 +126,7 @@ class Spacecraft(object, metaclass=SpacecraftMeta):
         if isinstance(cmds, str):
             cmds = get_backstop_cmds(cmds)
         self.cmds = cmds
-        self.obsreqs = {obsreq['obsid']: obsreq for obsreq in obsreqs} if obsreqs else None
+        self.obsreqs = obsreqs if obsreqs else None
         self.characteristics = characteristics
         # If starcheck is True, and hopper was called from starcheck, run in a reduced mode that
         # skips the star catalog checks (they are already being done independently in starcheck)
@@ -317,7 +317,7 @@ def run_cmds(cmds, or_list=None, ofls_characteristics_file=None,
     elif isinstance(or_list, list):
         obsreqs = or_list
     else:
-        obsreqs = parse_cm.read_or_list(or_list)
+        obsreqs, comments = parse_cm.read_or_list_full(or_list)
     if ofls_characteristics_file:
         odb_si_align = parse_cm.read_characteristics(ofls_characteristics_file,
                                                      item='ODB_SI_ALIGN')

--- a/hopper/tests/test_hopper.py
+++ b/hopper/tests/test_hopper.py
@@ -15,9 +15,6 @@ import hopper.base_cmd
 
 root = os.path.dirname(__file__)
 
-# The ode directory seems to have gone missing from this SOT MP directory use in the test
-# so setting the exists() to look for that missing piece should skip the now-broken tests
-HAS_OCT0515 = os.path.exists(os.path.join(root, 'OCT0515', 'mps', 'ode'))
 
 def run_hopper(backstop_file, or_list_file=None,
                ofls_characteristics_file=None, initial_state=None):
@@ -85,32 +82,6 @@ def test_nov0512_as_planned():
         for initfinal in ('initial', 'final'):
             for q in ('q1', 'q2', 'q3', 'q4'):
                 assert np.allclose(manvr[initfinal][q], sc_manvr[initfinal][q], atol=1e-7)
-
-
-@pytest.mark.skipif('not HAS_OCT0515')
-def test_oct0515():
-    """
-    More recent loads (not in version control)
-    """
-    root = os.path.dirname(__file__)
-    or_list_file = os.path.join(root, 'OCT0515', '*.or')
-    backstop_file = os.path.join(root, 'OCT0515', '*.backstop')
-    ofls_characteristics_file = os.path.join(root, 'OCT0515', 'mps', 'ode', 'characteristics',
-                                             'CHARACTERIS*')
-
-    initial_state = {'q1': -6.48322909e-01,
-                     'q2':6.38847453e-02,
-                     'q3':-5.54412345e-01,
-                     'q4':5.17902594e-01,
-                     'simpos': 75624,
-                     'simfa_pos': -468,
-                     'date': '2015-10-13 00:00:00'}
-
-    ok, lines, sc = run_hopper(glob.glob(backstop_file)[0],
-                               glob.glob(or_list_file)[0],
-                               glob.glob(ofls_characteristics_file)[0],
-                               initial_state)
-    assert ok
 
 
 def test_dither_commanding():


### PR DESCRIPTION
## Description

Update to use parse_cm.read_or_list_full

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested with the 2023.7 ska3-flight release that includes a read_or_list FutureWarning from parse_cm.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Confirmed unit tests hit the FutureWarning and this warning shows up with master but not this PR
```
hopper/tests/test_hopper.py::test_nov0512_as_planned
  /proj/sot/ska/jeanproj/git/hopper/hopper/spacecraft.py:320: FutureWarning: read_or_list is deprecated and will be removed, use read_or_list_full instead
    obsreqs = parse_cm.read_or_list(or_list)
```
Confirmed no FutureWarning when run with starcheck https://github.com/sot/starcheck/pull/430 to do a recent week.
